### PR TITLE
Add processed file tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 
 - Search function now checks `.zip` archives and extracts any contained CSV
   files under a `__extracted_csvs__` directory for further processing.
+- Processed file history is stored in DuckDB. The ``process_csv_files``
+  function can skip files that were already processed or reprocess them
+  when ``force=True``.


### PR DESCRIPTION
## Summary
- track processed files in DuckDB
- allow skipping or reprocessing CSV files

## Testing
- `pre-commit` *(fails: no pre-commit setup)*