### PR TITLE
Handle unsafe paths in zip members

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 - Search function now checks `.zip` archives and extracts any contained CSV
   files under a `__extracted_csvs__` directory for further processing.
+- When extracting from `.zip` archives, paths containing `..` or absolute paths
+  are skipped with a warning to avoid unintended file writes.
 - Processed file history is stored in DuckDB. The ``process_csv_files``
   function can skip files that were already processed or reprocess them
   when ``force=True``.

--- a/main.py
+++ b/main.py
@@ -19,12 +19,17 @@ def search_csv_file(target_path: Path, file_name_pattern: list[str]) -> list[Pat
         try:
             with zipfile.ZipFile(zip_path) as zf:
                 for member in zf.namelist():
-                    if not member.lower().endswith(".csv"):
+                    member_path = Path(member)
+                    # skip suspicious paths
+                    if member_path.is_absolute() or ".." in member_path.parts:
+                        print(f"warning: skip invalid path {member} in {zip_path}")
+                        continue
+                    if not member_path.name.lower().endswith(".csv"):
                         continue
                     extracted_dir = zip_path.parent / "__extracted_csvs__" / zip_path.stem
                     extracted_dir.mkdir(parents=True, exist_ok=True)
                     zf.extract(member, path=extracted_dir)
-                    csv_files.append(extracted_dir / member)
+                    csv_files.append(extracted_dir / member_path)
         except zipfile.BadZipFile:
             # skip files that are not valid zip archives
             continue


### PR DESCRIPTION
## Summary
- sanitize zip member paths before extracting
- document skip behavior for unsafe paths

## Testing
- `python -m py_compile main.py`