### PR TITLE
Add helper to process multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@
 - Processed file history is stored in DuckDB. The ``process_csv_files``
   function can skip files that were already processed or reprocess them
   when ``force=True``.
+- ``process_targets`` gathers CSV files from multiple directories or files
+  (including ``.zip``) and handles conversion, history updates and master table
+  updates in one call.


### PR DESCRIPTION
## Summary
- add `collect_csv_files` to gather CSVs from mixed paths
- add `process_targets` as an entry point that searches and processes files
- document new function in README

## Testing
- `python -m py_compile main.py`
