### PR TITLE
Add logging for processed file and row count

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,7 +235,7 @@ def write_parquet_file(
     machine_no: str,
     *,
     add_date_columns: bool = False,
-) -> None:
+) -> int:
     """Write ``lf`` to ``parquet_path`` partitioned by plant/machine and date.
 
     Parameters
@@ -251,6 +251,10 @@ def write_parquet_file(
         When ``True`` ``year`` and ``month`` columns are derived from the
         ``Datetime`` column before writing.  This should be disabled if these
         columns were already added upstream.
+    Returns
+    -------
+    int
+        Number of rows written to the Parquet dataset.
     """
 
     if add_date_columns:
@@ -269,6 +273,7 @@ def write_parquet_file(
     )
 
     df = lf.collect()
+    row_count = df.height
 
     tbl = df.to_arrow()
 
@@ -280,7 +285,8 @@ def write_parquet_file(
         existing_data_behavior="overwrite_or_ignore",
         create_dir=True,
     )
-    print(f"write {plant_name}/{machine_no} to parquet")
+
+    return row_count
 
 
 def _ensure_processed_table(con: duckdb.DuckDBPyConnection, table_name: str) -> None:
@@ -414,10 +420,12 @@ def process_csv_files(
         if not force and is_processed(fp, db_path, plant_name, machine_no):
             print(f"skip {fp} (already processed)")
             continue
+        print(f"processing {fp}")
         lf, header_lf = read_pi_file(fp)
         register_header_to_duckdb(header_lf, db_path, plant_name, machine_no)
-        write_parquet_file(lf, parquet_path, plant_name, machine_no)
+        row_count = write_parquet_file(lf, parquet_path, plant_name, machine_no)
         mark_processed(fp, db_path, plant_name, machine_no)
+        print(f"processed {fp}: {row_count} rows")
 
 
 def process_targets(


### PR DESCRIPTION
## Summary
- log the file currently being processed
- return row count from `write_parquet_file`
- print rows processed after each file is written

## Testing
- `python -m py_compile main.py`