### PR TITLE
Aggregate metadata from existing parquet files

### DIFF
--- a/main.py
+++ b/main.py
@@ -413,6 +413,40 @@ def write_parquet_file(
 
     tbl = df.to_arrow()
 
+    # 1) 既存メタデータ収集
+    existing_metas: list[pq.FileMetaData] = []
+    meta_file = parquet_path / "_metadata"
+    if meta_file.exists():
+        pf = pq.ParquetFile(meta_file)
+        existing_metas.append(pf.metadata)
+    else:
+        for p in parquet_path.rglob("*.parquet"):
+            try:
+                pf = pq.ParquetFile(p)
+                existing_metas.append(pf.metadata)
+            except Exception:
+                continue
+
+    # 1b) 既存メタデータとテーブルスキーマを統合
+    write_schema = pa.unify_schemas(
+        [tbl.schema] + [m.schema.to_arrow_schema() for m in existing_metas]
+    )
+
+    def _cast_table(table: pa.Table, schema: pa.Schema) -> pa.Table:
+        arrays: list[pa.Array] = []
+        names = set(table.schema.names)
+        for field in schema:
+            if field.name in names:
+                arr = table[field.name]
+                if not arr.type.equals(field.type):
+                    arr = arr.cast(field.type)
+            else:
+                arr = pa.nulls(table.num_rows, type=field.type)
+            arrays.append(arr)
+        return pa.Table.from_arrays(arrays, schema=schema)
+
+    tbl = _cast_table(tbl, write_schema)
+
     # 1) 書き出しつつ各ファイルのメタデータを収集
     meta_collector: list[pq.FileMetaData] = []
 
@@ -427,23 +461,23 @@ def write_parquet_file(
         existing_data_behavior="overwrite_or_ignore",
         create_dir=True,
         file_visitor=_visitor,
+        schema=write_schema,
     )
 
-    # 2) スキーマを統合
+    # 2) 既存と新規のメタデータからスキーマを統合
+    combined_metas = existing_metas + meta_collector
     unified_schema = pa.unify_schemas(
-
-        [m.schema.to_arrow_schema() for m in meta_collector]
-
+        [m.schema.to_arrow_schema() for m in combined_metas]
     )
 
     # 3) スキーマのみ
     pq.write_metadata(unified_schema, parquet_path / "_common_metadata")
 
-    # 4) スキーマ＋統計入り
+    # 4) スキーマ＋統計入り (全ファイル分)
     pq.write_metadata(
         unified_schema,
         parquet_path / "_metadata",
-        metadata_collector=meta_collector,
+        metadata_collector=combined_metas,
     )
 
     return row_count, column_count


### PR DESCRIPTION
## Summary
- gather existing parquet metadata when adding new files
- unify schemas using all existing metadata
- update `_metadata` and `_common_metadata` with combined info
- cast incoming tables to the unified schema before writing

## Testing
- `python -m py_compile main.py`
